### PR TITLE
Integrate front‑ and backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Node modules
+node_modules/
+
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build outputs
+/dist
+/dist-ssr
+
+# IDE files
+.vscode/
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,3 +1,52 @@
-Get started by customizing your environment (defined in the .idx/dev.nix file) with the tools and IDE extensions you'll need for your project!
+# Ride Share App
 
-Learn more at https://firebase.google.com/docs/studio/customize-workspace
+This project contains a simple Express backend and a React (Vite) frontend.
+
+## Setup
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) 18+
+- npm
+
+### Installation
+
+1. Install server dependencies:
+
+```bash
+cd rideshare-app/server
+npm install
+```
+
+2. Install client dependencies:
+
+```bash
+cd ../client
+npm install
+```
+
+### Environment Variables
+
+Create a `.env` file in `rideshare-app/server` based on `.env.example` and provide your MongoDB connection string and optional port number.
+
+For the client, copy `.env.example` to `.env` if you need to customize the API URL.
+
+### Running in Development
+
+Start the backend server:
+
+```bash
+cd rideshare-app/server
+node index.js
+```
+
+In a separate terminal, start the frontend:
+
+```bash
+cd rideshare-app/client
+npm run dev
+```
+
+The React app will load data from the backend URL defined in `VITE_API_URL`.
+
+*** End of File

--- a/rideshare-app/client/.env.example
+++ b/rideshare-app/client/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000

--- a/rideshare-app/client/src/App.jsx
+++ b/rideshare-app/client/src/App.jsx
@@ -5,7 +5,8 @@ function App() {
   const [message, setMessage] = useState('');
 
   useEffect(() => {
-    axios.get('http://localhost:5000')
+    const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+    axios.get(baseUrl)
       .then(res => setMessage(res.data))
       .catch(err => console.error(err));
   }, []);

--- a/rideshare-app/server/.env
+++ b/rideshare-app/server/.env
@@ -1,1 +1,0 @@
-MONGO_URI=mongodb+srv://Wolverine:Inspiron01@cluster0.i9g0nj0.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0

--- a/rideshare-app/server/.env.example
+++ b/rideshare-app/server/.env.example
@@ -1,0 +1,2 @@
+MONGO_URI=your_mongodb_connection_string
+PORT=5000

--- a/rideshare-app/server/index.js
+++ b/rideshare-app/server/index.js
@@ -6,7 +6,7 @@ require('dotenv').config();
 const rideRoutes = require('./routes/rides');
 
 const app = express();
-const PORT = 5000;
+const PORT = process.env.PORT || 5000;
 
 // Middleware
 app.use(cors());
@@ -14,6 +14,11 @@ app.use(express.json()); // 👈 this is crucial
 
 // Routes
 app.use('/api/rides', rideRoutes);
+
+// Simple base route for health check
+app.get('/', (req, res) => {
+  res.send('RideShare API running');
+});
 
 // DB connect
 mongoose.connect(process.env.MONGO_URI)


### PR DESCRIPTION
## Summary
- add a repo `.gitignore`
- secure credentials with `.env.example`
- make server port configurable and expose a base route
- load the API URL in the React app from env vars
- document setup in README

## Testing
- `npm test` in `server` *(fails: no tests defined)*
- `npm test` in `client` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b2563c8a0832098ca8c1477a3c8a4