### PR TITLE
Configure API URL via env and add dev proxy

### DIFF
--- a/rideshare-app/client/.env
+++ b/rideshare-app/client/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000

--- a/rideshare-app/client/src/App.jsx
+++ b/rideshare-app/client/src/App.jsx
@@ -5,7 +5,7 @@ function App() {
   const [message, setMessage] = useState('');
 
   useEffect(() => {
-    axios.get('http://localhost:5000')
+    axios.get(import.meta.env.VITE_API_URL)
       .then(res => setMessage(res.data))
       .catch(err => console.error(err));
   }, []);

--- a/rideshare-app/client/vite.config.js
+++ b/rideshare-app/client/vite.config.js
@@ -1,7 +1,18 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_API_URL,
+          changeOrigin: true,
+        },
+      },
+    },
+  };
 })


### PR DESCRIPTION
## Summary
- add `.env` file with `VITE_API_URL`
- use `import.meta.env.VITE_API_URL` in React app
- proxy `/api` calls in Vite config

## Testing
- `npm test` in `server` *(fails: Error: no test specified)*
- `npm test` in `client` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684b2d688f888320bc48281066bbb5ed